### PR TITLE
Replace Error with Errorf to match PR#3 in gowse

### DIFF
--- a/cmd/gowse-server/server.go
+++ b/cmd/gowse-server/server.go
@@ -27,7 +27,7 @@ func (l *logger) Infof(format string, v ...interface{}) {
 	l.Printf("info:%s", s)
 }
 
-func (l *logger) Error(format string, v ...interface{}) {
+func (l *logger) Errorf(format string, v ...interface{}) {
 	s := fmt.Sprintf(format, v...)
 	l.Printf("error:%s", s)
 }


### PR DESCRIPTION
Replace the use of `Error` for `Errorf` in the `logger` type to fit the new `Logger` interface in `gowse` provided by https://github.com/danfaizer/gowse/pull/3.